### PR TITLE
Lab 2

### DIFF
--- a/Python/Flask_Book_Library/project/customers/models.py
+++ b/Python/Flask_Book_Library/project/customers/models.py
@@ -22,7 +22,7 @@ class Customer(db.Model):
         print("Getting: " + str(self),flush=True)
 
     def __repr__(self):
-        return f"Customer(ID: {self.id}, Name: {self.name}, City: {self.city}, Age: {self.age}, Pesel: {self.pesel}, Street: {self.street}, AppNo: {self.appNo})"
+        return f"Customer(ID: {self.id}, Name: ***, City: ***, Age: ***, Pesel: ***, Street: ***, AppNo: ***)"
 
 
 with app.app_context():


### PR DESCRIPTION
# Zadanie 1
W logach przy stworzeniu nowego klienta w logach rejestrowane są wrażliwe dane:
![image](https://github.com/user-attachments/assets/11c68679-6372-465b-88e8-4e0e42617e9b)
Aby usunąć wyciek danych, zmieniony został plik customers/models.py i wrażliwe dane zostały zagwiazdkowane
![image](https://github.com/user-attachments/assets/b894e8b9-b654-4efe-b0aa-8b232850daeb)
# Zadanie 2
Znalezione wycieki w gitleaks:
![image](https://github.com/user-attachments/assets/a9d0eef6-c53d-418a-94e5-f377f2ddf093)

## Wyciek 1
![image](https://github.com/user-attachments/assets/67436f48-ffbf-40ff-b4e9-1c9b1d0d0910)
Wyciek dotyczy wycieku klucza RSA w jednym ze starszych commitów:
![image](https://github.com/user-attachments/assets/49ad53eb-3726-4fc1-90f4-6046b728b3a2)
## Wyciek 2
![image](https://github.com/user-attachments/assets/2685f977-c21f-4979-9fcd-e6e7805ea9f7)
Wyciek prywatnego klucza:
![image](https://github.com/user-attachments/assets/6d9bc574-7127-43c4-b2a3-e2b34be772ae)
## Wyciek 3 & 4
![image](https://github.com/user-attachments/assets/e695a7df-6230-4868-9c8b-ab24a42fd680)
![image](https://github.com/user-attachments/assets/19addec0-2617-4d2e-bfb8-9a5f93519f22)
Oba te wycieki dotyczą tego samego pliku, w którym możemy znaleźć:
![image](https://github.com/user-attachments/assets/7a63acb8-343d-433e-a6b7-d8b501afa07e)
Klucz prywatny jest niebezpiecznym wyciekiem, przy czym samo znalezienie "private_key_id" można potraktować jako false-positive, gdyż id nie daje bezpośrednio żadnych wrażliwych informacji.
# Zadanie 3
Wynik skanu:
![image](https://github.com/user-attachments/assets/e27c388a-9aeb-4d88-931c-e5cf9d0e2516)
![image](https://github.com/user-attachments/assets/50d04db0-b797-4e94-bd90-60a6464df579)
![image](https://github.com/user-attachments/assets/cf8c771d-c28e-44d7-9c18-035ab5f23202)
Wybrany jeden z dwóch wrażliwych pakietów o najwyższym severity:
![image](https://github.com/user-attachments/assets/908e64d8-b59e-4e49-8d4d-c09c8dd67887)
Uznany jako critical severity 9.8/10 ([CVE-2023-38545](https://github.com/advisories/GHSA-7xw9-w465-6x42))
Exploit polega na wykorzystaniu błędu w obsłudze nazw hostów przez curl podczas negocjacji z serwerem proxy SOCKS5. Jeśli nazwa hosta przekracza 255 bajtów, curl zamiast poprawnie przełączyć się na lokalne rozwiązywanie adresów, może skopiować zbyt długą nazwę hosta do bufora w pamięci. Dzieje się tak w wyniku nieprawidłowej wartości zmiennej lokalnej podczas wolnego procesu negocjacji SOCKS5, co prowadzi do przepełnienia bufora i potencjalnego naruszenia bezpieczeństwa.
### Zagrożenie w aplikacji
Zagrożenie wynika z pojawienia się starej wersji healpy w requirements-task.txt przez co healpy jest instalowany. Jako, że ta paczka nie jest wykorzystywana w aplikacji, nie ma ryzyka ataku przez ten błąd. Jednak dla uporządkowania zaleca się usunąć healpy z wymagań bądź usunąć cały ten plik, jako że istnieje już requirements.txt różniące się tylko o tę właśnie paczkę.
